### PR TITLE
Layout updates for additional form fields

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -29,6 +29,7 @@
 
           <div class="input-group">
             <label for="material-type">material </label>
+            <input type="checkbox" id="add-material" checked>
             <select id="material-type">
               <option value="PETG">
                 PETG
@@ -46,43 +47,38 @@
           </div>
           <div class="input-group">
             <label for="selected-date">date </label>
+            <input type="checkbox" id="add-date" checked>
             <select id="selected-date">
             </select>
           </div>
-          
-          <div class="input-group">
-            <label for="add-material">add material</label>
-            <input type="checkbox" id="add-material" checked>
-          </div>
 
-          <div class="input-group">
-            <label for="add-date">add date</label>
-            <input type="checkbox" id="add-date" checked>
-          </div>
-          <div class="input-group">
-            <label for="add-mouse-ears">add mouse ears (for bed adhesion)</label>
-            <input type="checkbox" id="add-mouse-ears" >
-          </div>
-          <div class="input-group">
-             <label for="selected-quality">Refinement (higher = slower and more triangles)</label>
-            <select id="selected-quality">
-              <option value="low">
-                Low
-              </option>
-              <option value="medium">
-                Medium
-              </option>
-              <option value="high">
-                High
-              </option>
-            </select>
-          </div>
+          
 
         </div>
 
         <!-- Right hand column -->
         <div class="column">
-          <input id="download-button" type="button" value="download">
+          <div class="input-group">
+            <label for="add-mouse-ears">add mouse ears (for bed adhesion)</label>
+            <input type="checkbox" id="add-mouse-ears" >
+          </div>
+          <div class="input-group">
+             <label for="selected-quality">Refinement</label>
+            <select id="selected-quality">
+              <option value="low">
+                Low (faster, fewer triangles)
+              </option>
+              <option value="medium">
+                Medium (in between)
+              </option>
+              <option value="high">
+                High (slower, more triangles)
+              </option>
+            </select>
+          </div>
+          <div class="input-group">
+            <input id="download-button" type="button" value="download">
+          </div>
         </div>
 
       </div>

--- a/dist/style.css
+++ b/dist/style.css
@@ -85,12 +85,26 @@ input[type=number]::-webkit-outer-spin-button {
 
 }
 
-.input-group input,
+.input-group input[type="number"],
+.input-group input[type="text"],
 .input-group select {
   min-width: 250px;
   margin: 0;
   padding: 0.25em;
 }
+
+.input-group input[type=checkbox] {
+  margin-right: 0.5rem;
+}
+
+.input-group input[type=checkbox] + input[type="number"],
+.input-group input[type=checkbox] + input[type="text"],
+.input-group input[type=checkbox] + select {
+  min-width: 225px;
+  margin: 0;
+  padding: 0.25em;
+}
+
 
 #viewerContainer {
   width: 900px;

--- a/src/main.js
+++ b/src/main.js
@@ -89,10 +89,12 @@ function init(){
   }
   addDateCheckbox.onchange = function(){
     modelConfig.addDate = addDateCheckbox.checked;
+    dateDropdown.disabled = !addDateCheckbox.checked;
     updateModel();  
   }
   addMaterialCheckbox.onchange = function(){
     modelConfig.addMaterial = addMaterialCheckbox.checked;
+    materialTypeDropdown.disabled = !addMaterialCheckbox.checked;
     updateModel();  
   }
   addMouseEarsCheckbox.onchange = function(){


### PR DESCRIPTION
Shunted some input fields into the right-hand column.
Moved the "add date" and "add material" checkboxes in-line with the drop-down for each of those. 
Tweaked the JS so the "Material" and "Date" dropdowns are disabled if the material or date isn't being added to the model -- hopefully this makes it pretty clear what those checkboxes are doing, without needing an additional label